### PR TITLE
Fix chmod routine in SET main script

### DIFF
--- a/setoolkit
+++ b/setoolkit
@@ -116,13 +116,18 @@ update_config()
 # chmod routine
 if operating_system == "posix":
     # change permissions if nix
-    subprocess.Popen("chmod +x seautomate;"
-                     "chmod +x set-update;"
-                     "chmod +x setup.py;"
-                     "chmod +x set-proxy;"
-                     "chmod +x src/payloads/ratte/ratteserver;"
-                     "chmod +x src/payloads/set_payloads/listener.py",
-                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    files_to_chmod = [
+        "seautomate",
+        "set-update",
+        "setup.py",
+        "set-proxy",
+        "src/payloads/ratte/ratteserver",
+        "src/payloads/set_payloads/listener.py",
+    ]
+    for _file in files_to_chmod:
+        subprocess.run(["chmod", "+x", _file],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE)
 
 dns = core.check_config("DNS_SERVER=")
 if dns.lower() == "on":


### PR DESCRIPTION
## Summary
- replace invalid subprocess.Popen usage for chmod commands with per-file loop using subprocess.run

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6896d0caffd88322abe6387e226ac6df