### PR TITLE
fix comment for POSIX OS check in seproxy

### DIFF
--- a/seproxy
+++ b/seproxy
@@ -22,7 +22,7 @@ except NameError:
 # grab the operating system
 operating_system = core.check_os()
 
-# if windows then do some stuff
+# if POSIX then do some stuff
 if operating_system == "posix":
 
     definepath = os.getcwd()


### PR DESCRIPTION
## Summary
- clarify the comment describing the POSIX operating system check in `seproxy`

## Testing
- `python -m py_compile seproxy`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896d232dfa083228935ea95503eb291